### PR TITLE
Improve acyclic visitor. Add compile time check for prerequirements

### DIFF
--- a/include/ezvis/ezvis/ezvis.hpp
+++ b/include/ezvis/ezvis/ezvis.hpp
@@ -14,10 +14,10 @@
 
 #include <concepts>
 #include <cstdint>
-#include <map>
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 
 namespace ezvis {
 
@@ -67,7 +67,7 @@ template <typename t_traits> struct vtable {
   using function_type = typename t_traits::function_type;
 
 private:
-  std::map<detail::unique_tag_type, function_type> m_table;
+  std::unordered_map<detail::unique_tag_type, function_type> m_table;
 
 public:
   template <typename t_visitable> void add(function_type func) {


### PR DESCRIPTION
- Change map to unordered_map
- Add static_assert for uniqueness of tags used for dispatching
- Rewrite read/write_little_endian. Make check for mixed endianness a compile time static_assert.