### PR TITLE
Const qualifications for ast dumper and copier

### DIFF
--- a/include/frontend/ast/ast_copier.hpp
+++ b/include/frontend/ast/ast_copier.hpp
@@ -20,7 +20,7 @@ namespace paracl::frontend::ast {
 
 class ast_container;
 
-class ast_copier : public ezvis::visitor_base<i_ast_node, ast_copier, i_ast_node &> {
+class ast_copier : public ezvis::visitor_base<const i_ast_node, ast_copier, i_ast_node &> {
   using to_visit = tuple_ast_nodes;
   ast_container &m_container;
 
@@ -29,17 +29,17 @@ public:
 
   EZVIS_VISIT(to_visit);
 
-  assignment_statement &copy(assignment_statement &);
-  binary_expression    &copy(binary_expression &);
-  constant_expression  &copy(constant_expression &);
-  if_statement         &copy(if_statement &);
-  print_statement      &copy(print_statement &);
-  read_expression      &copy(read_expression &);
-  statement_block      &copy(statement_block &);
-  unary_expression     &copy(unary_expression &);
-  variable_expression  &copy(variable_expression &);
-  while_statement      &copy(while_statement &);
-  error_node           &copy(error_node &);
+  assignment_statement &copy(const assignment_statement &);
+  binary_expression    &copy(const binary_expression &);
+  constant_expression  &copy(const constant_expression &);
+  if_statement         &copy(const if_statement &);
+  print_statement      &copy(const print_statement &);
+  read_expression      &copy(const read_expression &);
+  statement_block      &copy(const statement_block &);
+  unary_expression     &copy(const unary_expression &);
+  variable_expression  &copy(const variable_expression &);
+  while_statement      &copy(const while_statement &);
+  error_node           &copy(const error_node &);
 
   EZVIS_VISIT_INVOKER(copy);
 };

--- a/include/frontend/ast/ast_nodes/i_ast_node.hpp
+++ b/include/frontend/ast/ast_nodes/i_ast_node.hpp
@@ -21,7 +21,7 @@ protected:
 
 public:
   EZVIS_VISITABLE();
-  location loc() { return m_loc; }
+  location loc() const { return m_loc; }
 
   i_ast_node() = default;
   i_ast_node(location l) : m_loc{l} {}

--- a/include/frontend/dumper.hpp
+++ b/include/frontend/dumper.hpp
@@ -19,7 +19,7 @@
 
 namespace paracl::frontend::ast {
 
-class ast_dumper final : public ezvis::visitor_base<i_ast_node, ast_dumper, void> {
+class ast_dumper final : public ezvis::visitor_base<const i_ast_node, ast_dumper, void> {
 private:
   using to_visit = tuple_ast_nodes;
 
@@ -41,17 +41,17 @@ public:
 
   EZVIS_VISIT(to_visit);
 
-  void dump(assignment_statement &);
-  void dump(binary_expression &);
-  void dump(constant_expression &);
-  void dump(if_statement &);
-  void dump(print_statement &);
-  void dump(read_expression &);
-  void dump(statement_block &);
-  void dump(unary_expression &);
-  void dump(variable_expression &);
-  void dump(while_statement &);
-  void dump(error_node &);
+  void dump(const assignment_statement &);
+  void dump(const binary_expression &);
+  void dump(const constant_expression &);
+  void dump(const if_statement &);
+  void dump(const print_statement &);
+  void dump(const read_expression &);
+  void dump(const statement_block &);
+  void dump(const unary_expression &);
+  void dump(const variable_expression &);
+  void dump(const while_statement &);
+  void dump(const error_node &);
 
   EZVIS_VISIT_INVOKER(dump);
 };

--- a/src/frontend/ast_copier.cc
+++ b/src/frontend/ast_copier.cc
@@ -18,28 +18,32 @@ namespace paracl::frontend::ast {
 
 template <typename T> T &trivial_ast_node_copy(const T &ref, ast_container &cont) { return cont.make_node<T>(ref); }
 
-read_expression     &ast_copier::copy(read_expression &ref) { return trivial_ast_node_copy(ref, m_container); }
-variable_expression &ast_copier::copy(variable_expression &ref) { return trivial_ast_node_copy(ref, m_container); }
-error_node          &ast_copier::copy(error_node &ref) { return trivial_ast_node_copy(ref, m_container); }
-constant_expression &ast_copier::copy(constant_expression &ref) { return trivial_ast_node_copy(ref, m_container); }
+read_expression     &ast_copier::copy(const read_expression &ref) { return trivial_ast_node_copy(ref, m_container); }
+variable_expression &ast_copier::copy(const variable_expression &ref) {
+  return trivial_ast_node_copy(ref, m_container);
+}
+error_node          &ast_copier::copy(const error_node &ref) { return trivial_ast_node_copy(ref, m_container); }
+constant_expression &ast_copier::copy(const constant_expression &ref) {
+  return trivial_ast_node_copy(ref, m_container);
+}
 
-binary_expression &ast_copier::copy(binary_expression &ref) {
+binary_expression &ast_copier::copy(const binary_expression &ref) {
   return m_container.make_node<binary_expression>(ref.op_type(), apply(ref.left()), apply(ref.right()), ref.loc());
 }
 
-print_statement &ast_copier::copy(print_statement &ref) {
+print_statement &ast_copier::copy(const print_statement &ref) {
   return m_container.make_node<print_statement>(apply(ref.expr()), ref.loc());
 }
 
-unary_expression &ast_copier::copy(unary_expression &ref) {
+unary_expression &ast_copier::copy(const unary_expression &ref) {
   return m_container.make_node<unary_expression>(ref.op_type(), apply(ref.expr()), ref.loc());
 }
 
-while_statement &ast_copier::copy(while_statement &ref) {
+while_statement &ast_copier::copy(const while_statement &ref) {
   return m_container.make_node<while_statement>(apply(ref.cond()), apply(ref.block()), ref.loc());
 }
 
-assignment_statement &ast_copier::copy(assignment_statement &ref) {
+assignment_statement &ast_copier::copy(const assignment_statement &ref) {
   auto &copy = m_container.make_node<assignment_statement>(*ref.rbegin(), ref.right(), ref.loc());
 
   for (auto start = std::next(ref.rbegin()), finish = ref.rend(); start != finish; ++start) {
@@ -49,7 +53,7 @@ assignment_statement &ast_copier::copy(assignment_statement &ref) {
   return copy;
 }
 
-if_statement &ast_copier::copy(if_statement &ref) {
+if_statement &ast_copier::copy(const if_statement &ref) {
   if (ref.else_block()) {
     return m_container.make_node<if_statement>(apply(ref.cond()), apply(ref.true_block()), apply(*ref.else_block()),
                                                ref.loc());
@@ -58,7 +62,7 @@ if_statement &ast_copier::copy(if_statement &ref) {
   return m_container.make_node<if_statement>(apply(ref.cond()), apply(ref.true_block()), ref.loc());
 }
 
-statement_block &ast_copier::copy(statement_block &ref) {
+statement_block &ast_copier::copy(const statement_block &ref) {
   auto &copy = m_container.make_node<statement_block>();
 
   for (const auto &v : ref) {

--- a/src/frontend/dumper.cc
+++ b/src/frontend/dumper.cc
@@ -18,22 +18,22 @@
 
 namespace paracl::frontend::ast {
 
-void ast_dumper::dump(error_node &ref) { print_declare_node(m_os, ref, "<error>"); }
-void ast_dumper::dump(read_expression &ref) { print_declare_node(m_os, ref, "<read> ?"); }
+void ast_dumper::dump(const error_node &ref) { print_declare_node(m_os, ref, "<error>"); }
+void ast_dumper::dump(const read_expression &ref) { print_declare_node(m_os, ref, "<read> ?"); }
 
-void ast_dumper::dump(variable_expression &ref) {
+void ast_dumper::dump(const variable_expression &ref) {
   std::stringstream ss;
   ss << "<identifier> " << ref.name();
   print_declare_node(m_os, ref, ss.str());
 }
 
-void ast_dumper::dump(constant_expression &ref) {
+void ast_dumper::dump(const constant_expression &ref) {
   std::stringstream ss;
   ss << "<integer constant> " << std::dec << ref.value();
   print_declare_node(m_os, ref, ss.str());
 }
 
-void ast_dumper::dump(binary_expression &ref) {
+void ast_dumper::dump(const binary_expression &ref) {
   std::stringstream ss;
   ss << "<binary_expression> " << ast::binary_operation_to_string(ref.op_type());
   print_declare_node(m_os, ref, ss.str());
@@ -45,7 +45,7 @@ void ast_dumper::dump(binary_expression &ref) {
   apply(ref.right());
 }
 
-void ast_dumper::dump(unary_expression &ref) {
+void ast_dumper::dump(const unary_expression &ref) {
   std::stringstream ss;
   ss << "<binary_expression> " << ast::unary_operation_to_string(ref.op_type());
 
@@ -55,7 +55,7 @@ void ast_dumper::dump(unary_expression &ref) {
   apply(ref.expr());
 }
 
-void ast_dumper::dump(assignment_statement &ref) {
+void ast_dumper::dump(const assignment_statement &ref) {
   print_declare_node(m_os, ref, "<assignment>");
   const i_ast_node *prev = &ref;
 
@@ -72,7 +72,7 @@ void ast_dumper::dump(assignment_statement &ref) {
   apply(ref.right());
 }
 
-void ast_dumper::dump(if_statement &ref) {
+void ast_dumper::dump(const if_statement &ref) {
   print_declare_node(m_os, ref, "<if>");
 
   print_bind_node(m_os, ref, ref.cond(), "<condition>");
@@ -87,13 +87,13 @@ void ast_dumper::dump(if_statement &ref) {
   }
 }
 
-void ast_dumper::dump(print_statement &ref) {
+void ast_dumper::dump(const print_statement &ref) {
   print_declare_node(m_os, ref, "<print_statement>");
   print_bind_node(m_os, ref, ref.expr());
   apply(ref.expr());
 }
 
-void ast_dumper::dump(statement_block &ref) {
+void ast_dumper::dump(const statement_block &ref) {
   print_declare_node(m_os, ref, "<statement_block>");
 
   for (const auto &v : ref) {
@@ -102,7 +102,7 @@ void ast_dumper::dump(statement_block &ref) {
   }
 }
 
-void ast_dumper::dump(while_statement &ref) {
+void ast_dumper::dump(const while_statement &ref) {
   print_declare_node(m_os, ref, "<while>");
 
   print_bind_node(m_os, ref, ref.cond(), "<condition>");


### PR DESCRIPTION
- Change std::remove_cv to std::remove_cv_t (Bug)
- Make it possible to const qualify visitors to preserve semantics
- Make dumper and copier const visitors