### PR TITLE
Make vtable creation constexpr friendly

### DIFF
--- a/include/codegen.hpp
+++ b/include/codegen.hpp
@@ -83,7 +83,7 @@ class codegen_visitor final : public ezvis::visitor_base<frontend::ast::i_ast_no
 public:
   codegen_visitor() = default;
 
-  EZVIS_VISIT(to_visit);
+  EZVIS_VISIT_CT(to_visit);
 
   void generate(frontend::ast::assignment_statement &);
   void generate(frontend::ast::binary_expression &);

--- a/include/ezvis/ezvis/ezvis.hpp
+++ b/include/ezvis/ezvis/ezvis.hpp
@@ -13,6 +13,7 @@
 #include <ctti/type_id.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <concepts>
 #include <cstdint>

--- a/include/frontend/ast/ast_copier.hpp
+++ b/include/frontend/ast/ast_copier.hpp
@@ -27,7 +27,7 @@ class ast_copier : public ezvis::visitor_base<const i_ast_node, ast_copier, i_as
 public:
   ast_copier(ast_container &container) : m_container{container} {}
 
-  EZVIS_VISIT(to_visit);
+  EZVIS_VISIT_CT(to_visit);
 
   assignment_statement &copy(const assignment_statement &);
   binary_expression    &copy(const binary_expression &);

--- a/include/frontend/dumper.hpp
+++ b/include/frontend/dumper.hpp
@@ -39,7 +39,7 @@ private:
 public:
   explicit ast_dumper(std::ostream &os) : m_os{os} {}
 
-  EZVIS_VISIT(to_visit);
+  EZVIS_VISIT_CT(to_visit);
 
   void dump(const assignment_statement &);
   void dump(const binary_expression &);

--- a/include/frontend/semantic_analyzer.hpp
+++ b/include/frontend/semantic_analyzer.hpp
@@ -40,7 +40,7 @@ private:
   }
 
 public:
-  EZVIS_VISIT(to_visit);
+  EZVIS_VISIT_CT(to_visit);
 
   // clang-format off
   void analyze_node(ast::read_expression &) { /* Do nothing */ }


### PR DESCRIPTION
- Implement naive constexpr map using std::array
- Add options to create vtable at compile time or runtime with two respective macros EZVIS_VISIT_CT and EZVIS_VISIT_RT
- Change static assert to concept
- Make all visitors use newer EZVIS_VISIT_CT