### PR TITLE
[Formatting] Change ```.clang-format``` config file and reformat most files accordingly. Add formatting CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,24 +2,24 @@
 Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
+AlignAfterOpenBracket: BlockIndent
+AlignArrayOfStructures: Left
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: true
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Right
-AlignOperands:   Align
+AlignOperands:   DontAlign
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -100,10 +100,11 @@ IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentExternBlock: AfterExternBlock
-IndentRequires:  false
+IndentRequires:  true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 InsertTrailingCommas: None
+InsertBraces: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
@@ -130,6 +131,7 @@ PointerAlignment: Right
 PPIndentWidth:   -1
 ReferenceAlignment: Pointer
 ReflowComments:  true
+RequiresClausePosition: OwnLine
 ShortNamespaceLines: 1
 SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
@@ -152,6 +154,7 @@ SpacesInAngles:  Never
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
+SeparateDefinitionBlocks: Leave
 SpacesInLineCommentPrefix:
   Minimum:         1
   Maximum:         -1
@@ -159,13 +162,15 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 BitFieldColonSpacing: Both
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'inline', 'const', 'type', 'volatile' ]
 Standard:        Latest
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TabWidth:        8
+TabWidth:        2
 UseCRLF:         false
 UseTab:          Never
 WhitespaceSensitiveMacros:
@@ -175,4 +180,3 @@ WhitespaceSensitiveMacros:
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
 ...
-

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,31 @@
+name: Check formatting with clang-format
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        path:
+          - 'include'
+          - 'src'
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.10.2
+      with:
+        clang-format-version: '15'
+        check-path: ${{ matrix.path }}
+        exclude-regex: (3rd-party)

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Install dependencies
-      run: sudo apt-get install libboost-all-dev libgtest-dev flex libfl-dev cmake
+      run: sudo apt-get update && sudo apt-get install libboost-all-dev libgtest-dev flex libfl-dev cmake
     
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,12 @@ project(paracl)
 
 option(INSOURCEBUILD OFF)
 
-if((${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR}) AND NOT ${INSOURCEBUILD})
-  message(FATAL_ERROR "In-source building disabled. Provide -DINSOURCEBUILD option if you are sure about it.")
+if((${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR}) AND NOT
+                                                              ${INSOURCEBUILD})
+  message(
+    FATAL_ERROR
+      "In-source building disabled. Provide -DINSOURCEBUILD option if you are sure about it."
+  )
 endif()
 
 set(CMAKE_CXX_STANDARD 20)
@@ -17,37 +21,37 @@ else()
 endif()
 
 find_package(GTest)
-set(NOGTEST OFF CACHE BOOL "Disable GoogleTest")
+set(NOGTEST
+    OFF
+    CACHE BOOL "Disable GoogleTest")
 
 enable_testing()
-if(NOT NOGTEST AND GTEST_FOUND AND CMAKE_MINOR_VERSION GREATER_EQUAL 20)
+if(NOT NOGTEST
+   AND GTEST_FOUND
+   AND CMAKE_MINOR_VERSION GREATER_EQUAL 20)
   set(ENABLE_GTEST ON)
 else()
   message(WARNING "Google Test disabled")
 endif()
 
-set(NOLINT ON CACHE BOOL "Disable clang-tidy")
+set(NOLINT
+    ON
+    CACHE BOOL "Disable clang-tidy")
 
 if(NOT ${NOLINT})
-find_program(CLANG_TIDY_COMMAND clang-tidy)
-if(CLANG_TIDY_COMMAND)
+  find_program(CLANG_TIDY_COMMAND clang-tidy)
+  if(CLANG_TIDY_COMMAND)
 
-# Clang-tidy for linting
-set(CMAKE_CXX_CLANG_TIDY 
-  clang-tidy;
-  -checks=google-*,cppcoreguidelines-*
-)
-set(CMAKE_C_CLANG_TIDY 
-  clang-tidy;
-  -checks=google-*,cppcoreguidelines-*
-)
+    # Clang-tidy for linting
+    set(CMAKE_CXX_CLANG_TIDY clang-tidy; -checks=google-*,cppcoreguidelines-*)
+    set(CMAKE_C_CLANG_TIDY clang-tidy; -checks=google-*,cppcoreguidelines-*)
+
+  else()
+    message(WARNING "Unable to find clang-tidy, linter disabled")
+  endif()
 
 else()
-message(WARNING "Unable to find clang-tidy, linter disabled")
-endif()
-
-else()
-message(WARNING "-DNOLINT option provided, linter disabled")
+  message(WARNING "-DNOLINT option provided, linter disabled")
 endif()
 
 set(DCMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -60,27 +64,23 @@ target_link_libraries(ezvis INTERFACE ctti)
 # Add flags for GNU sampling profiler gprof in Debug build and RelWithDebInfo
 
 option(PROFILE OFF)
-if (PROFILE)
+if(PROFILE)
   add_compile_options(-pg)
   add_link_options(-pg)
 endif()
 
 option(SANITIZE OFF)
-if (SANITIZE)
+if(SANITIZE)
   add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
   add_link_options(-fsanitize=undefined -fno-omit-frame-pointer)
 endif()
 
-set(BYTECODE_VM_SOURCES
-  src/bytecode_vm/decl_vm.cc
-)
+set(BYTECODE_VM_SOURCES src/bytecode_vm/decl_vm.cc)
 
 add_library(bytecode_vm STATIC ${BYTECODE_VM_SOURCES})
 target_include_directories(bytecode_vm PUBLIC include)
 
-set(PCLDIS_SOURCES
-  src/pcldis.cc
-)
+set(PCLDIS_SOURCES src/pcldis.cc)
 
 add_library(popl INTERFACE)
 target_include_directories(popl INTERFACE 3rd-party/popl)
@@ -88,36 +88,42 @@ target_include_directories(popl INTERFACE 3rd-party/popl)
 add_executable(pcldis ${PCLDIS_SOURCES})
 target_link_libraries(pcldis popl bytecode_vm)
 
-set(PCLVM_SOURCES
-  src/pclvm.cc
-)
+set(PCLVM_SOURCES src/pclvm.cc)
 
 add_executable(pclvm ${PCLVM_SOURCES})
 target_link_libraries(pclvm popl bytecode_vm)
 
-# Find bison and flex and set CMP0098 policy to new to use binary dir 
+# Find bison and flex and set CMP0098 policy to new to use binary dir
 find_package(FLEX REQUIRED)
 find_package(BISON 3.5 REQUIRED)
 
-bison_target(parser src/frontend/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.y.cc DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/bison_paracl_parser.hpp)
-flex_target(scanner src/frontend/scanner.l ${CMAKE_CURRENT_BINARY_DIR}/scanner.l.cc)
+bison_target(
+  parser src/frontend/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.y.cc
+  DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/bison_paracl_parser.hpp)
+flex_target(scanner src/frontend/scanner.l
+            ${CMAKE_CURRENT_BINARY_DIR}/scanner.l.cc)
 add_flex_bison_dependency(scanner parser)
 
 set(PARACL_COMPILER_SOURCES
-  src/frontend/dumper.cc
-  src/frontend/semantic_analyzer.cc
-  src/frontend/ast_copier.cc
-  src/codegen.cc
-)
+    src/frontend/dumper.cc src/frontend/semantic_analyzer.cc
+    src/frontend/ast_copier.cc src/codegen.cc)
 
-add_library(paracl_compiler STATIC ${PARACL_COMPILER_SOURCES} ${BISON_parser_OUTPUTS} ${FLEX_scanner_OUTPUTS})
-target_include_directories(paracl_compiler PUBLIC include ${CMAKE_CURRENT_BINARY_DIR})
+add_library(
+  paracl_compiler STATIC ${PARACL_COMPILER_SOURCES} ${BISON_parser_OUTPUTS}
+                         ${FLEX_scanner_OUTPUTS})
+target_include_directories(paracl_compiler PUBLIC include
+                                                  ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(paracl_compiler ezvis)
 
 add_executable(pclc src/pclc.cc)
 target_link_libraries(pclc PUBLIC popl paracl_compiler bytecode_vm)
 
 if(BASH_PROGRAM)
-  add_test(NAME test.paracl.external COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh "$<TARGET_FILE:pclc>" ${CMAKE_CURRENT_SOURCE_DIR}/test/external)
-  add_test(NAME test.paracl.basic COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh "$<TARGET_FILE:pclc>" ${CMAKE_CURRENT_SOURCE_DIR}/test/basic)
+  add_test(
+    NAME test.paracl.external
+    COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh
+            "$<TARGET_FILE:pclc>" ${CMAKE_CURRENT_SOURCE_DIR}/test/external)
+  add_test(NAME test.paracl.basic
+           COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/test.sh
+                   "$<TARGET_FILE:pclc>" ${CMAKE_CURRENT_SOURCE_DIR}/test/basic)
 endif()

--- a/include/bytecode_vm/bytecode_builder.hpp
+++ b/include/bytecode_vm/bytecode_builder.hpp
@@ -43,7 +43,7 @@ template <typename t_desc> struct encoded_instruction {
   }
 
 public:
-  auto    get_size() const { return t_desc::get_size(); }
+  auto get_size() const { return t_desc::get_size(); }
   uint8_t get_opcode() const { return t_desc::get_opcode(); }
 
   void encode(auto iter) const {
@@ -69,7 +69,7 @@ public:
 
 private:
   std::vector<instruction_variant_type> m_code;
-  uint32_t                              m_cur_loc = 0;
+  uint32_t m_cur_loc = 0;
 
 public:
   bytecode_builder() = default;

--- a/include/bytecode_vm/decl_vm.hpp
+++ b/include/bytecode_vm/decl_vm.hpp
@@ -40,7 +40,7 @@ using binary_code_buffer_type = std::vector<uint8_t>;
 class chunk {
 private:
   binary_code_buffer_type m_binary_code;
-  constant_pool_type      m_constant_pool;
+  constant_pool_type m_constant_pool;
 
 public:
   using value_type = uint8_t;
@@ -74,7 +74,7 @@ public:
 };
 
 std::optional<chunk> read_chunk(std::istream &);
-void                 write_chunk(std::ostream &, const chunk &);
+void write_chunk(std::ostream &, const chunk &);
 
 template <typename, typename> struct instruction;
 
@@ -86,7 +86,7 @@ template <opcode_underlying_type ident, typename... Ts> struct instruction_desc 
   const std::string_view name;
   using attribute_types = std::tuple<Ts...>;
 
-  constexpr auto        get_name() const { return name; }
+  constexpr auto get_name() const { return name; }
   static constexpr auto get_opcode() { return opcode; }
   static constexpr auto get_size() { return binary_size; }
 
@@ -119,7 +119,7 @@ template <typename t_desc, typename t_action> struct instruction {
   using attribute_tuple_type = typename description_type::attribute_types;
 
   const t_desc description;
-  t_action     action = nullptr;
+  t_action action = nullptr;
 
   constexpr instruction(t_desc p_description, t_action p_action) : description{p_description}, action{p_action} {}
   constexpr auto get_name() const { return description.get_name(); }
@@ -132,7 +132,7 @@ template <typename t_desc, typename t_action> struct instruction {
   }
 
   struct decoded_instruction {
-    const instruction   *instr;
+    const instruction *instr;
     attribute_tuple_type attributes;
   };
 
@@ -162,11 +162,11 @@ template <typename t_desc> struct context {
   friend class virtual_machine<t_desc>;
 
 private:
-  std::vector<execution_value_type>       m_execution_stack;
+  std::vector<execution_value_type> m_execution_stack;
   binary_code_buffer_type::const_iterator m_ip, m_ip_end;
 
   chunk m_program_code;
-  bool  m_halted = false;
+  bool m_halted = false;
 
 public:
   context() = default;
@@ -176,7 +176,7 @@ public:
     m_ip_end = m_program_code.binary_end();
   }
 
-  auto  ip() const { return m_ip; }
+  auto ip() const { return m_ip; }
   auto &at_stack(uint32_t index) & { return m_execution_stack.at(index); }
 
   void set_ip(uint32_t new_ip) {
@@ -212,7 +212,7 @@ template <typename... t_instructions> struct instruction_set_description {
 };
 
 template <typename t_desc> class virtual_machine {
-  t_desc          instruction_set;
+  t_desc instruction_set;
   context<t_desc> m_execution_context;
 
 public:

--- a/include/bytecode_vm/virtual_machine.hpp
+++ b/include/bytecode_vm/virtual_machine.hpp
@@ -23,120 +23,120 @@
 namespace paracl::bytecode_vm::instruction_set {
 
 constexpr decl_vm::instruction_desc<E_PUSH_CONST_UNARY, uint32_t> push_const_desc = "push_const";
-constexpr auto                                                    push_const_instr = push_const_desc >>
-                                  [](auto &&ctx, auto &&attr) { ctx.push(ctx.constant(std::get<0>(attr))); };
+constexpr auto push_const_instr = push_const_desc >>
+    [](auto &&ctx, auto &&attr) { ctx.push(ctx.constant(std::get<0>(attr))); };
 
 constexpr decl_vm::instruction_desc<E_RETURN_NULLARY> return_desc = "ret";
 constexpr auto return_instr = return_desc >> [](auto &&ctx, auto &&) { ctx.halt(); };
 
 constexpr decl_vm::instruction_desc<E_POP_NULLARY> pop_desc = "pop";
-constexpr auto                                     pop_instr = pop_desc >> [](auto &&ctx, auto &&) { ctx.pop(); };
+constexpr auto pop_instr = pop_desc >> [](auto &&ctx, auto &&) { ctx.pop(); };
 
 constexpr decl_vm::instruction_desc<E_ADD_NULLARY> add_desc = "add";
-constexpr auto                                     add_instr = add_desc >> [](auto &&ctx, auto &&) {
+constexpr auto add_instr = add_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first + second);
 };
 
 constexpr decl_vm::instruction_desc<E_SUB_NULLARY> sub_desc = "sub";
-constexpr auto                                     sub_instr = sub_desc >> [](auto &&ctx, auto &&) {
+constexpr auto sub_instr = sub_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first - second);
 };
 
 constexpr decl_vm::instruction_desc<E_MUL_NULLARY> mul_desc = "mul";
-constexpr auto                                     mul_instr = mul_desc >> [](auto &&ctx, auto &&) {
+constexpr auto mul_instr = mul_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first * second);
 };
 
 constexpr decl_vm::instruction_desc<E_DIV_NULLARY> div_desc = "div";
-constexpr auto                                     div_instr = div_desc >> [](auto &&ctx, auto &&) {
+constexpr auto div_instr = div_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first / second);
 };
 
 constexpr decl_vm::instruction_desc<E_MOD_NULLARY> mod_desc = "mod";
-constexpr auto                                     mod_instr = mod_desc >> [](auto &&ctx, auto &&) {
+constexpr auto mod_instr = mod_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first % second);
 };
 
 constexpr decl_vm::instruction_desc<E_AND_NULLARY> and_desc = "and";
-constexpr auto                                     and_instr = and_desc >> [](auto &&ctx, auto &&) {
+constexpr auto and_instr = and_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first && second);
 };
 
 constexpr decl_vm::instruction_desc<E_OR_NULLARY> or_desc = "or";
-constexpr auto                                    or_instr = or_desc >> [](auto &&ctx, auto &&) {
+constexpr auto or_instr = or_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first || second);
 };
 
 constexpr decl_vm::instruction_desc<E_NOT_NULLARY> not_desc = "not";
-constexpr auto                                     not_instr = not_desc >> [](auto &&ctx, auto &&) {
+constexpr auto not_instr = not_desc >> [](auto &&ctx, auto &&) {
   auto first = ctx.pop();
   ctx.push(!first);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_EQ_NULLARY> cmp_eq_desc = "cmp_eq";
-constexpr auto                                        cmp_eq_instr = cmp_eq_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_eq_instr = cmp_eq_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first == second);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_NE_NULLARY> cmp_ne_desc = "cmp_ne";
-constexpr auto                                        cmp_ne_instr = cmp_ne_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_ne_instr = cmp_ne_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first != second);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_GT_NULLARY> cmp_gt_desc = "cmp_gt";
-constexpr auto                                        cmp_gt_instr = cmp_gt_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_gt_instr = cmp_gt_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first > second);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_LS_NULLARY> cmp_ls_desc = "cmp_ls";
-constexpr auto                                        cmp_ls_instr = cmp_ls_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_ls_instr = cmp_ls_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first < second);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_GE_NULLARY> cmp_ge_desc = "cmp_ge";
-constexpr auto                                        cmp_ge_instr = cmp_ge_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_ge_instr = cmp_ge_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first >= second);
 };
 
 constexpr decl_vm::instruction_desc<E_CMP_LE_NULLARY> cmp_le_desc = "cmp_le";
-constexpr auto                                        cmp_le_instr = cmp_le_desc >> [](auto &&ctx, auto &&) {
+constexpr auto cmp_le_instr = cmp_le_desc >> [](auto &&ctx, auto &&) {
   auto second = ctx.pop();
   auto first = ctx.pop();
   ctx.push(first <= second);
 };
 
 constexpr decl_vm::instruction_desc<E_PRINT_NULLARY> print_desc = "print";
-constexpr auto                                       print_instr = print_desc >> [](auto &&ctx, auto &&) {
+constexpr auto print_instr = print_desc >> [](auto &&ctx, auto &&) {
   auto first = ctx.pop();
   std::cout << std::dec << first << "\n";
 };
 
 constexpr decl_vm::instruction_desc<E_PUSH_READ_NULLARY> push_read_desc = "push_read";
-constexpr auto                                           push_read = push_read_desc >> [](auto &&ctx, auto &&) {
+constexpr auto push_read = push_read_desc >> [](auto &&ctx, auto &&) {
   int val;
   std::cin >> val;
   ctx.push(val);
@@ -177,7 +177,8 @@ constexpr auto jmp_false_instr = jmp_false_desc >> [](auto &&ctx, auto &&attr) {
 static const auto paracl_isa = decl_vm::instruction_set_description(
     push_const_instr, return_instr, pop_instr, add_instr, sub_instr, mul_instr, div_instr, mod_instr, and_instr,
     or_instr, cmp_eq_instr, cmp_ne_instr, cmp_gt_instr, cmp_ls_instr, cmp_ge_instr, cmp_le_instr, print_instr,
-    push_read, mov_local_instr, push_local_instr, jmp_instr, jmp_true_instr, jmp_false_instr, not_instr);
+    push_read, mov_local_instr, push_local_instr, jmp_instr, jmp_true_instr, jmp_false_instr, not_instr
+);
 
 } // namespace paracl::bytecode_vm::instruction_set
 

--- a/include/codegen.hpp
+++ b/include/codegen.hpp
@@ -32,18 +32,18 @@ namespace paracl::codegen {
 class codegen_symtab_stack final {
 private:
   std::vector<std::unordered_map<std::string, uint32_t>> m_stack;
-
   uint32_t total_count = 0;
 
 public:
   uint32_t lookup_location(const std::string &name) const {
     for (auto its = m_stack.rbegin(), ite = m_stack.rend(); its != ite; ++its) {
       const auto &elem = *its;
-      auto        found = elem.find(name);
+      auto found = elem.find(name);
       if (found != elem.end()) return found->second;
     }
 
-    throw std::logic_error{"Codegen: trying to look up location of a variable not present in the symbol table"};
+    throw std::logic_error{"Codegen: trying to look up location of a variable "
+                           "not present in the symbol table"};
   }
 
   void begin_scope() { m_stack.emplace_back(); }
@@ -62,13 +62,13 @@ public:
 class codegen_visitor final : public ezvis::visitor_base<frontend::ast::i_ast_node, codegen_visitor, void> {
   using builder_type = bytecode_vm::builder::bytecode_builder<decltype(bytecode_vm::instruction_set::paracl_isa)>;
 
+private:
   std::unordered_map<int, uint32_t> m_constant_map;
-
   codegen_symtab_stack m_symtab_stack;
-  builder_type         m_builder;
-
+  builder_type m_builder;
   bool m_is_currently_statement = false;
 
+private:
   void set_currently_statement();
   void reset_currently_statement();
   bool is_currently_statement() const;

--- a/include/ezvis/ezvis/ezvis.hpp
+++ b/include/ezvis/ezvis/ezvis.hpp
@@ -89,8 +89,8 @@ public:
   }
 
   constexpr std::size_t size() const { return c_size; }
-  constexpr auto        begin() const { return m_map.begin(); }
-  constexpr auto        end() const { return m_map.end(); }
+  constexpr auto begin() const { return m_map.begin(); }
+  constexpr auto end() const { return m_map.end(); }
 };
 
 } // namespace detail
@@ -134,7 +134,7 @@ using vtable_storage_t = typename vtable_storage<t_traits, t_size, t_storage_fla
 template <typename t_traits, typename t_storage_flag, typename t_to_visit> struct vtable {};
 
 template <typename t_traits, typename t_storage_flag, typename... t_types>
-requires unique_hash_values<typename t_traits::base_type, std::tuple<t_types...>>
+  requires unique_hash_values<typename t_traits::base_type, std::tuple<t_types...>>
 // It is very unlikely that there will be collisions with a 64-bit hash, but we should verify it nontheless.
 struct vtable<t_traits, t_storage_flag, std::tuple<t_types...>> {
   using base_type = typename t_traits::base_type;
@@ -150,8 +150,8 @@ private:
   static constexpr std::pair<detail::unique_tag_type, function_type> make_id_func_pair() {
     constexpr auto tag = detail::unique_tag<base_type, t_visitable>();
     // Static cast to avoid UB. See https://en.cppreference.com/w/cpp/language/pointer
-    constexpr auto ptr = static_cast<function_type>(
-        &visitor_type::template thunk_ezvis__<visitor_type, t_visitable, typename visitor_type::invoker_ezvis__>);
+    constexpr auto ptr = static_cast<function_type>(&visitor_type::template thunk_ezvis__<
+                                                    visitor_type, t_visitable, typename visitor_type::invoker_ezvis__>);
     return {tag, ptr};
   }
 
@@ -188,13 +188,14 @@ public:
                                 };
 
     static_assert(has_invoke, "Invoker type does not have an appropriate invoke method");
-    return t_invoker::template invoke<t_return_type>(static_cast<t_visitor &>(*this),
-                                                     static_cast<const_valid_visitable &>(base));
+    return t_invoker::template invoke<t_return_type>(
+        static_cast<t_visitor &>(*this), static_cast<const_valid_visitable &>(base)
+    );
   }
 
 public:
   return_type apply(base_type &base) {
-    const auto   *vtable = static_cast<t_concrete_visitor &>(*this).template get_vtable_ezviz__<vtable_traits_type>();
+    const auto *vtable = static_cast<t_concrete_visitor &>(*this).template get_vtable_ezviz__<vtable_traits_type>();
     function_type thunk = vtable->get(base.unique_tag_ezvis__());
     return (static_cast<t_concrete_visitor &>(*this).*thunk)(base);
   }

--- a/include/frontend/ast/ast_container.hpp
+++ b/include/frontend/ast/ast_container.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */
@@ -25,7 +25,7 @@ using i_ast_node_uptr = std::unique_ptr<i_ast_node>;
 class ast_container final {
 private:
   std::vector<i_ast_node_uptr> m_nodes;
-  i_ast_node                  *m_root = nullptr;
+  i_ast_node *m_root = nullptr;
 
   template <typename T, typename... Ts> T &emplace_back(Ts &&...args) {
     auto uptr = std::make_unique<T>(std::forward<Ts>(args)...);
@@ -39,7 +39,7 @@ public:
 
   ast_container(const ast_container &other) {
     ast_container temp;
-    auto          root_ptr = ast_copy(other.get_root_ptr(), temp);
+    auto root_ptr = ast_copy(other.get_root_ptr(), temp);
     temp.set_root_ptr(root_ptr);
     *this = std::move(temp);
   }
@@ -63,7 +63,7 @@ public:
 
   template <typename t_node_type, typename... t_args>
   t_node_type &make_node(t_args &&...args)
-  requires std::is_base_of_v<i_ast_node, t_node_type>
+    requires std::is_base_of_v<i_ast_node, t_node_type>
   {
     return emplace_back<t_node_type>(std::forward<t_args>(args)...);
   }

--- a/include/frontend/ast/ast_copier.hpp
+++ b/include/frontend/ast/ast_copier.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */
@@ -30,16 +30,16 @@ public:
   EZVIS_VISIT_CT(to_visit);
 
   assignment_statement &copy(const assignment_statement &);
-  binary_expression    &copy(const binary_expression &);
-  constant_expression  &copy(const constant_expression &);
-  if_statement         &copy(const if_statement &);
-  print_statement      &copy(const print_statement &);
-  read_expression      &copy(const read_expression &);
-  statement_block      &copy(const statement_block &);
-  unary_expression     &copy(const unary_expression &);
-  variable_expression  &copy(const variable_expression &);
-  while_statement      &copy(const while_statement &);
-  error_node           &copy(const error_node &);
+  binary_expression &copy(const binary_expression &);
+  constant_expression &copy(const constant_expression &);
+  if_statement &copy(const if_statement &);
+  print_statement &copy(const print_statement &);
+  read_expression &copy(const read_expression &);
+  statement_block &copy(const statement_block &);
+  unary_expression &copy(const unary_expression &);
+  variable_expression &copy(const variable_expression &);
+  while_statement &copy(const while_statement &);
+  error_node &copy(const error_node &);
 
   EZVIS_VISIT_INVOKER(copy);
 };

--- a/include/frontend/ast/ast_nodes/assignment_statement.hpp
+++ b/include/frontend/ast/ast_nodes/assignment_statement.hpp
@@ -20,7 +20,7 @@ namespace paracl::frontend::ast {
 class assignment_statement final : public i_ast_node {
 private:
   std::vector<variable_expression> m_lefts;
-  i_ast_node                      *m_right;
+  i_ast_node *m_right;
 
 public:
   EZVIS_VISITABLE();

--- a/include/frontend/ast/ast_nodes/binary_expression.hpp
+++ b/include/frontend/ast/ast_nodes/binary_expression.hpp
@@ -57,7 +57,7 @@ constexpr std::string_view binary_operation_to_string(binary_operation op) {
 
 class binary_expression final : public i_ast_node {
   binary_operation m_operation_type;
-  i_ast_node      *m_left, *m_right;
+  i_ast_node *m_left, *m_right;
 
 public:
   EZVIS_VISITABLE();

--- a/include/frontend/ast/ast_nodes/i_ast_node.hpp
+++ b/include/frontend/ast/ast_nodes/i_ast_node.hpp
@@ -41,8 +41,8 @@ class variable_expression;
 class while_statement;
 class error_node;
 
-using tuple_ast_nodes =
-    std::tuple<assignment_statement, binary_expression, constant_expression, if_statement, print_statement,
-               read_expression, statement_block, unary_expression, variable_expression, while_statement, error_node>;
+using tuple_ast_nodes = std::tuple<
+    assignment_statement, binary_expression, constant_expression, if_statement, print_statement, read_expression,
+    statement_block, unary_expression, variable_expression, while_statement, error_node>;
 
 } // namespace paracl::frontend::ast

--- a/include/frontend/ast/ast_nodes/if_statement.hpp
+++ b/include/frontend/ast/ast_nodes/if_statement.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */

--- a/include/frontend/ast/ast_nodes/statement_block.hpp
+++ b/include/frontend/ast/ast_nodes/statement_block.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */
@@ -20,7 +20,7 @@ namespace paracl::frontend::ast {
 
 class statement_block final : public i_ast_node {
 private:
-  symtab                    m_symtab;
+  symtab m_symtab;
   std::vector<i_ast_node *> m_statements;
 
 public:

--- a/include/frontend/ast/ast_nodes/unary_expression.hpp
+++ b/include/frontend/ast/ast_nodes/unary_expression.hpp
@@ -32,14 +32,15 @@ constexpr std::string_view unary_operation_to_string(unary_operation op) {
   case unary_op::E_UN_OP_NOT: return "!";
   }
 
-  assert(0); // We really shouldn't get here. If we do, then someone has broken the enum class intentionally.
+  assert(0); // We really shouldn't get here. If we do, then someone has broken
+             // the enum class intentionally.
   throw std::invalid_argument{"Broken enum"};
 }
 
 class unary_expression final : public i_ast_node {
 private:
   unary_operation m_operation_type;
-  i_ast_node     *m_expr;
+  i_ast_node *m_expr;
 
 public:
   EZVIS_VISITABLE();
@@ -48,7 +49,7 @@ public:
       : i_ast_node{l}, m_operation_type{op_type}, m_expr{&p_expr} {}
 
   unary_operation op_type() const { return m_operation_type; }
-  i_ast_node     &expr() const { return *m_expr; }
+  i_ast_node &expr() const { return *m_expr; }
 };
 
 } // namespace paracl::frontend::ast

--- a/include/frontend/ast/ast_nodes/while_statement.hpp
+++ b/include/frontend/ast/ast_nodes/while_statement.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */
@@ -18,7 +18,7 @@ namespace paracl::frontend::ast {
 
 class while_statement final : public i_ast_node {
 private:
-  symtab      m_symtab;
+  symtab m_symtab;
   i_ast_node *m_condition;
   i_ast_node *m_block;
 

--- a/include/frontend/dumper.hpp
+++ b/include/frontend/dumper.hpp
@@ -30,8 +30,8 @@ private:
     os << "\tnode_0x" << std::hex << utils::pointer_to_uintptr(&ref) << " [label = \"" << label << "\" ];\n";
   }
 
-  static void print_bind_node(std::ostream &os, const i_ast_node &parent, const i_ast_node &child,
-                              std::string_view label = "") {
+  static void
+  print_bind_node(std::ostream &os, const i_ast_node &parent, const i_ast_node &child, std::string_view label = "") {
     os << "\tnode_0x" << std::hex << utils::pointer_to_uintptr(&parent) << " -> node_0x"
        << utils::pointer_to_uintptr(&child) << " [label = \"" << label << "\" ];\n";
   }

--- a/include/frontend/error.hpp
+++ b/include/frontend/error.hpp
@@ -18,7 +18,7 @@ namespace paracl::frontend {
 
 struct error_kind final {
   std::string error_message;
-  location    loc;
+  location loc;
 };
 
 } // namespace paracl::frontend

--- a/include/frontend/frontend_driver.hpp
+++ b/include/frontend/frontend_driver.hpp
@@ -24,10 +24,10 @@ namespace paracl::frontend {
 class frontend_driver final {
 private:
   scanner m_scanner;
-  parser  m_parser;
+  parser m_parser;
 
   std::optional<error_kind> m_current_error;
-  ast::ast_container        m_ast;
+  ast::ast_container m_ast;
 
   friend class parser;
   friend class scanner;

--- a/include/frontend/scanner.hpp
+++ b/include/frontend/scanner.hpp
@@ -28,7 +28,7 @@ class frontend_driver;
 class scanner final : public yyFlexLexer {
 private:
   frontend_driver &m_driver;
-  position         m_pos;
+  position m_pos;
 
   frontend_driver &driver() { return m_driver; }
 
@@ -36,7 +36,7 @@ public:
   scanner(frontend_driver &driver) : m_driver{driver} {}
 
   paracl::frontend::parser::symbol_type get_next_token();
-  position                             &pos() { return m_pos; }
+  position &pos() { return m_pos; }
 };
 
 } // namespace paracl::frontend

--- a/include/frontend/semantic_analyzer.hpp
+++ b/include/frontend/semantic_analyzer.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */
@@ -22,7 +22,7 @@ namespace paracl::frontend {
 class semantic_analyzer final : public ezvis::visitor_base<ast::i_ast_node, semantic_analyzer, void> {
 private:
   symtab_stack m_scopes;
-  bool         m_valid = true;
+  bool m_valid = true;
 
   enum class semantic_analysis_state {
     E_LVALUE,

--- a/include/frontend/symtab.hpp
+++ b/include/frontend/symtab.hpp
@@ -1,9 +1,9 @@
 /*
  * ----------------------------------------------------------------------------
  * "THE BEER-WARE LICENSE" (Revision 42):
- * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long as you
- * retain this notice you can do whatever you want with this stuff. If we meet
- * some day, and you think this stuff is worth it, you can buy me a beer in
+ * <tsimmerman.ss@phystech.edu>, <alex.rom23@mail.ru> wrote this file.  As long
+ * as you retain this notice you can do whatever you want with this stuff. If we
+ * meet some day, and you think this stuff is worth it, you can buy me a beer in
  * return.
  * ----------------------------------------------------------------------------
  */

--- a/include/utils/serialization.hpp
+++ b/include/utils/serialization.hpp
@@ -27,8 +27,9 @@ namespace paracl::utils {
 namespace detail {
 
 inline auto get_iterator_endian(std::span<char> raw_bytes) {
-  static_assert(std::endian::native == std::endian::little || std::endian::native == std::endian::big,
-                "Mixed endian, bailing out");
+  static_assert(
+      std::endian::native == std::endian::little || std::endian::native == std::endian::big, "Mixed endian, bailing out"
+  );
   if constexpr (std::endian::native == std::endian::little) {
     return raw_bytes.begin();
   } else {
@@ -40,12 +41,12 @@ inline auto get_iterator_endian(std::span<char> raw_bytes) {
 
 template <typename T, std::input_iterator iter>
 std::pair<std::optional<T>, iter> read_little_endian(iter first, iter last)
-requires std::integral<T> || std::floating_point<T>
+  requires std::integral<T> || std::floating_point<T>
 {
   std::array<char, sizeof(T)> raw_bytes;
 
   const auto input_iter = detail::get_iterator_endian(raw_bytes);
-  auto       size = sizeof(T);
+  auto size = sizeof(T);
   first = copy_while(first, last, input_iter, [&size](auto) { return size && size--; });
 
   if (size != 0) return std::make_pair(std::nullopt, first);
@@ -54,12 +55,12 @@ requires std::integral<T> || std::floating_point<T>
 
 template <typename T, std::output_iterator<uint8_t> iter>
 void write_little_endian(T val, iter oput)
-requires std::integral<T> || std::floating_point<T>
+  requires std::integral<T> || std::floating_point<T>
 {
   std::array<char, sizeof(T)> raw_bytes = std::bit_cast<decltype(raw_bytes)>(val);
 
   const auto input_iter = detail::get_iterator_endian(raw_bytes);
-  auto       size = sizeof(T);
+  auto size = sizeof(T);
   std::copy_n(input_iter, size, oput);
 }
 
@@ -73,6 +74,8 @@ struct padded_hex {
 
 constexpr auto padded_hex_printer = padded_hex{};
 
-template <typename T> auto pointer_to_uintptr(T *pointer) { return std::bit_cast<uintptr_t>(pointer); }
+template <typename T> auto pointer_to_uintptr(T *pointer) {
+  return std::bit_cast<uintptr_t>(pointer);
+}
 
 } // namespace paracl::utils

--- a/src/bytecode_vm/decl_vm.cc
+++ b/src/bytecode_vm/decl_vm.cc
@@ -10,7 +10,7 @@
 
 namespace paracl::bytecode_vm::decl_vm {
 
-constexpr unsigned                                magic_bytes_length = 6;
+constexpr unsigned magic_bytes_length = 6;
 constexpr std::array<uint8_t, magic_bytes_length> header = {0xB, 0x0, 0x0, 0xB, 0xE, 0xC};
 
 std::optional<chunk> read_chunk(std::istream &is) {

--- a/src/codegen.cc
+++ b/src/codegen.cc
@@ -66,7 +66,6 @@ void codegen_visitor::generate(ast::assignment_statement &ref) {
 }
 
 void codegen_visitor::generate(ast::binary_expression &ref) {
-
   reset_currently_statement();
   apply(ref.left());
 
@@ -119,13 +118,12 @@ void codegen_visitor::generate(ast::binary_expression &ref) {
 }
 
 void codegen_visitor::generate(ast::statement_block &ref) {
-
   m_symtab_stack.begin_scope();
 
   for (const auto &v : *ref.symbol_table()) {
     m_symtab_stack.push_variable(v);
-    m_builder.emit_operation(
-        vm_builder::encoded_instruction{vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
+    m_builder.emit_operation(vm_builder::encoded_instruction{
+        vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
   }
 
   for (auto &statement : ref) {
@@ -150,14 +148,13 @@ void codegen_visitor::visit_if_no_else(ast::if_statement &ref) {
   set_currently_statement();
   apply(ref.true_block());
 
-  auto  jump_to_index = m_builder.current_loc();
+  auto jump_to_index = m_builder.current_loc();
   auto &to_relocate = m_builder.get_as(vm_instruction_set::jmp_false_desc, index_jmp_to_false_block);
 
   std::get<0>(to_relocate.m_attr) = jump_to_index;
 }
 
 void codegen_visitor::visit_if_with_else(ast::if_statement &ref) {
-
   reset_currently_statement();
   apply(ref.cond());
 
@@ -184,8 +181,8 @@ void codegen_visitor::generate(ast::if_statement &ref) {
 
   for (const auto &v : *ref.control_block_symtab()) {
     m_symtab_stack.push_variable(v);
-    m_builder.emit_operation(
-        vm_builder::encoded_instruction{vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
+    m_builder.emit_operation(vm_builder::encoded_instruction{
+        vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
   }
 
   if (!ref.else_block()) {
@@ -206,8 +203,8 @@ void codegen_visitor::generate(ast::while_statement &ref) {
 
   for (const auto &v : *ref.symbol_table()) {
     m_symtab_stack.push_variable(v);
-    m_builder.emit_operation(
-        vm_builder::encoded_instruction{vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
+    m_builder.emit_operation(vm_builder::encoded_instruction{
+        vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
   }
 
   auto while_location_start = m_builder.current_loc();
@@ -236,8 +233,8 @@ void codegen_visitor::generate(ast::unary_expression &ref) {
   reset_currently_statement();
   switch (ref.op_type()) {
   case unary_op::E_UN_OP_NEG: {
-    m_builder.emit_operation(
-        vm_builder::encoded_instruction{vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
+    m_builder.emit_operation(vm_builder::encoded_instruction{
+        vm_instruction_set::push_const_desc, lookup_or_insert_constant(0)});
     apply(ref.expr());
     m_builder.emit_operation(vm_builder::encoded_instruction{vm_instruction_set::sub_desc});
     break;
@@ -256,12 +253,20 @@ void codegen_visitor::generate(ast::unary_expression &ref) {
   }
 }
 
-void codegen_visitor::set_currently_statement() { m_is_currently_statement = true; }
-void codegen_visitor::reset_currently_statement() { m_is_currently_statement = false; }
-bool codegen_visitor::is_currently_statement() const { return m_is_currently_statement; }
+void codegen_visitor::set_currently_statement() {
+  m_is_currently_statement = true;
+}
+
+void codegen_visitor::reset_currently_statement() {
+  m_is_currently_statement = false;
+}
+
+bool codegen_visitor::is_currently_statement() const {
+  return m_is_currently_statement;
+}
 
 uint32_t codegen_visitor::lookup_or_insert_constant(int constant) {
-  auto     found = m_constant_map.find(constant);
+  auto found = m_constant_map.find(constant);
   uint32_t index;
 
   if (found == m_constant_map.end()) {

--- a/src/frontend/ast_copier.cc
+++ b/src/frontend/ast_copier.cc
@@ -16,13 +16,22 @@
 
 namespace paracl::frontend::ast {
 
-template <typename T> T &trivial_ast_node_copy(const T &ref, ast_container &cont) { return cont.make_node<T>(ref); }
+template <typename T> T &trivial_ast_node_copy(const T &ref, ast_container &cont) {
+  return cont.make_node<T>(ref);
+}
 
-read_expression     &ast_copier::copy(const read_expression &ref) { return trivial_ast_node_copy(ref, m_container); }
+read_expression &ast_copier::copy(const read_expression &ref) {
+  return trivial_ast_node_copy(ref, m_container);
+}
+
 variable_expression &ast_copier::copy(const variable_expression &ref) {
   return trivial_ast_node_copy(ref, m_container);
 }
-error_node          &ast_copier::copy(const error_node &ref) { return trivial_ast_node_copy(ref, m_container); }
+
+error_node &ast_copier::copy(const error_node &ref) {
+  return trivial_ast_node_copy(ref, m_container);
+}
+
 constant_expression &ast_copier::copy(const constant_expression &ref) {
   return trivial_ast_node_copy(ref, m_container);
 }
@@ -55,8 +64,9 @@ assignment_statement &ast_copier::copy(const assignment_statement &ref) {
 
 if_statement &ast_copier::copy(const if_statement &ref) {
   if (ref.else_block()) {
-    return m_container.make_node<if_statement>(apply(ref.cond()), apply(ref.true_block()), apply(*ref.else_block()),
-                                               ref.loc());
+    return m_container.make_node<if_statement>(
+        apply(ref.cond()), apply(ref.true_block()), apply(*ref.else_block()), ref.loc()
+    );
   }
 
   return m_container.make_node<if_statement>(apply(ref.cond()), apply(ref.true_block()), ref.loc());

--- a/src/frontend/dumper.cc
+++ b/src/frontend/dumper.cc
@@ -18,8 +18,13 @@
 
 namespace paracl::frontend::ast {
 
-void ast_dumper::dump(const error_node &ref) { print_declare_node(m_os, ref, "<error>"); }
-void ast_dumper::dump(const read_expression &ref) { print_declare_node(m_os, ref, "<read> ?"); }
+void ast_dumper::dump(const error_node &ref) {
+  print_declare_node(m_os, ref, "<error>");
+}
+
+void ast_dumper::dump(const read_expression &ref) {
+  print_declare_node(m_os, ref, "<read> ?");
+}
 
 void ast_dumper::dump(const variable_expression &ref) {
   std::stringstream ss;

--- a/src/frontend/semantic_analyzer.cc
+++ b/src/frontend/semantic_analyzer.cc
@@ -17,8 +17,13 @@
 
 namespace paracl::frontend {
 
-void semantic_analyzer::analyze_node(ast::unary_expression &ref) { apply(ref.expr()); }
-void semantic_analyzer::analyze_node(ast::error_node &ref) { report_error(ref.error_msg(), ref.loc()); }
+void semantic_analyzer::analyze_node(ast::unary_expression &ref) {
+  apply(ref.expr());
+}
+
+void semantic_analyzer::analyze_node(ast::error_node &ref) {
+  report_error(ref.error_msg(), ref.loc());
+}
 
 void semantic_analyzer::analyze_node(ast::assignment_statement &ref) {
   set_state(semantic_analysis_state::E_LVALUE);

--- a/src/pclc.cc
+++ b/src/pclc.cc
@@ -20,7 +20,7 @@
 
 int main(int argc, char *argv[]) {
   std::string input_file_name;
-  bool        dump_binary = false;
+  bool dump_binary = false;
 
   popl::OptionParser op("Allowed options");
 
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (output_file_option->is_set()) {
-    std::string   output_file_name = output_file_option->value();
+    std::string output_file_name = output_file_option->value();
     std::ofstream output_file;
 
     output_file.exceptions(exception_mask);

--- a/src/pcldis.cc
+++ b/src/pcldis.cc
@@ -1,8 +1,8 @@
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <ostream>
-#include <fstream>
 #include <string>
-#include <filesystem>
 
 #include "bytecode_vm/bytecode_builder.hpp"
 #include "bytecode_vm/decl_vm.hpp"

--- a/src/pclvm.cc
+++ b/src/pclvm.cc
@@ -16,8 +16,8 @@ int main(int argc, char *argv[]) {
   std::string input_file_name;
 
   popl::OptionParser op("Allowed options");
-  auto               help_option = op.add<popl::Switch>("h", "help", "Print this help message");
-  auto               input_file_option = op.add<popl::Value<std::string>>("i", "input", "Specify input file");
+  auto help_option = op.add<popl::Switch>("h", "help", "Print this help message");
+  auto input_file_option = op.add<popl::Value<std::string>>("i", "input", "Specify input file");
   op.parse(argc, argv);
 
   if (help_option->is_set()) {


### PR DESCRIPTION
- Modify current ```.clang-format``` config
- Add CI job to check formatting on push/pull-request
- Reformat CMakeLists.txt using default config of cmake-format